### PR TITLE
Adding additional options to control the program using the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ The sample executable is called `dino_danger`. You can run it from the **Microso
 You can also get more info about the command line options by running:
 
     dino_danger.exe --help
-    --data-dir Location of the resource folders.
-    --adapter-id Integer that allows to pick the desired GPU.
-    --poi Integer that allows to pick the initial camera location.
-    --disable-coop Disable cooperative vector usage at launch.
-    --enable-animation Enable mesh animation at launch.
+        --data-dir Location of the resource folders.
+        --adapter-id Integer that allows to pick the desired GPU [-1 = Largest VRAM, >= 0 System adapter ID].
+        --poi Integer that allows to pick the initial camera location.
+        --disable-coop Disable cooperative vector usage at launch.
+        --disable-animation Disable mesh animation at launch.
+        --rendering-mode Pick the rendering mode [0 = Material, 1 = GBuffer, 2 = Debug].
+        --texture-mode Pick the texture mode [0 = Uncompressed, 1 = BC6, 2 = Neural].
+        --filtering-mode Pick the filtering mode [0 = Nearest, 1 = Linear, 2 = Anisotropic].
 
 ## License
 Intel® Texture Set Neural Compression Sample is licensed under the [MIT License](LICENSE).

--- a/sdk/include/math/operators.h
+++ b/sdk/include/math/operators.h
@@ -10,7 +10,12 @@
 // SDK includes
 #include "math/types.h"
 
+#pragma region int
+	int clamp(int v, int minV, int maxV);
+#pragma endregion
+
 #pragma region float
+	float clamp(float v, float minV, float maxV);
 	float min3(float v0, float v1, float v2);
 	float max3(float v0, float v1, float v2);
 	float lerp(const float& v0, const float& v1, float f);

--- a/sdk/include/tools/command_line.h
+++ b/sdk/include/tools/command_line.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// Project includes
+#include "render_pipeline/types.h"
+
 // System includes
 #include <vector>
 #include <string>
@@ -17,7 +20,7 @@ struct CommandLineOptions
 	std::string dataDir = ".";
 
 	// Adapter index (as returned by OS)
-	uint32_t adapterIndex = 0;
+	int32_t adapterIndex = -1;
 
 	// Picking an initial POI
 	uint32_t initialPOI = 0;
@@ -26,7 +29,16 @@ struct CommandLineOptions
 	bool enableCooperative = true;
 
 	// Mesh animation enabled at start
-	bool enableAnimation = true;
+	bool disableAnimation = false;
+
+	// Control the rendering mode
+	RenderingMode renderingMode = RenderingMode::GBufferDeferred;
+
+	// Control the texture mode
+	TextureMode textureMode = TextureMode::Neural;
+
+	// Filtering mode
+	FilteringMode filteringMode = FilteringMode::Anisotropic;
 };
 
 namespace command_line

--- a/sdk/src/dx12/dx12_backend_graphics_device.cpp
+++ b/sdk/src/dx12/dx12_backend_graphics_device.cpp
@@ -184,7 +184,7 @@ namespace d3d12
             DXGI_ADAPTER_DESC1 dxgiAdapterDesc1;
             adapter->GetDesc1(&dxgiAdapterDesc1);
             dx12_device->adapterName = convert_to_regular(dxgiAdapterDesc1.Description);
-            // wprintf(L"Picked GPU: %s\n", dxgiAdapterDesc1.Description);
+            wprintf(L"Picked GPU: %s\n", dxgiAdapterDesc1.Description);
             // wprintf(L"GPU Memory: %" PRIu64 L"\n", dxgiAdapterDesc1.DedicatedVideoMemory);
 
             // Create the graphics device and ensure it's been succesfully created

--- a/sdk/src/math/operators.cpp
+++ b/sdk/src/math/operators.cpp
@@ -18,11 +18,24 @@ OT sign(IT value) {
     return 0;
 }
 
+#pragma region int
+    int clamp(int v, int minV, int maxV)
+    {
+        return std::min(std::max(v, minV), maxV);
+    }
+#pragma endregion
+
 #pragma region float
+    float clamp(float v, float minV, float maxV)
+    {
+        return std::min(std::max(v, minV), maxV);
+    }
+
     float max3(float v0, float v1, float v2)
     {
         return std::max({ v0, v1, v2 });
     }
+
     float min3(float v0, float v1, float v2)
     {
         return std::min({ v0, v1, v2 });

--- a/sdk/src/render_pipeline/dino_renderer.cpp
+++ b/sdk/src/render_pipeline/dino_renderer.cpp
@@ -56,7 +56,13 @@ void DinoRenderer::initialize(uint64_t hInstance, const CommandLineOptions& opti
     graphics::setup_graphics_api(GraphicsAPI::DX12);
     // graphics::device::enable_debug_layer();
     graphics::device::enable_experimental_features();
-    m_Device = graphics::device::create_graphics_device();
+
+    // Create the device based on the criteria
+    if (options.adapterIndex >= 0 )
+        m_Device = graphics::device::create_graphics_device(DevicePickStrategy::AdapterID, options.adapterIndex);
+    else
+        m_Device = graphics::device::create_graphics_device(DevicePickStrategy::VRAMSize);
+
     m_Window = graphics::window::create_window(m_Device, (uint64_t)hInstance, 1920, 1080, "Intel TSNC (DX12)");
     m_CmdQueue = graphics::command_queue::create_command_queue(m_Device);
     m_SwapChain = graphics::swap_chain::create_swap_chain(m_Window, m_Device, m_CmdQueue, FRAME_BUFFER_FORMAT);
@@ -80,10 +86,10 @@ void DinoRenderer::initialize(uint64_t hInstance, const CommandLineOptions& opti
     m_CameraController.move_to_poi(options.initialPOI);
 
     // Initial setup
-    m_RenderingMode = RenderingMode::GBufferDeferred;
-    m_TextureMode = TextureMode::Neural;
+    m_RenderingMode = options.renderingMode;
+    m_TextureMode = options.textureMode;
     m_DebugMode = DebugMode::TileInfo;
-    m_FilteringMode = FilteringMode::Linear;
+    m_FilteringMode = options.filteringMode;
     m_DisplayUI = true;
     m_UseCooperativeVectors = m_CooperativeVectorsSupported ? options.enableCooperative : false;
     m_EnableCounters = false;
@@ -164,7 +170,7 @@ void DinoRenderer::initialize(uint64_t hInstance, const CommandLineOptions& opti
     m_GBuffer = graphics::resources::create_graphics_buffer(m_Device, numPixels * sizeof(uint16_t) * numChannels, sizeof(uint16_t), GraphicsBufferType::Default);
 
     // Post setups
-    m_MeshRenderer.set_animation_state(options.enableAnimation);
+    m_MeshRenderer.set_animation_state(!options.disableAnimation);
 }
 
 void DinoRenderer::reload_shaders()

--- a/sdk/src/tools/command_line.cpp
+++ b/sdk/src/tools/command_line.cpp
@@ -7,6 +7,10 @@
  
  // Includes
 #include "tools/command_line.h"
+#include "math/operators.h"
+
+// System includes
+#include <algorithm>
 
 namespace command_line
 {
@@ -56,19 +60,52 @@ namespace command_line
 				commandLineOptions.enableCooperative = false;
 				current_arg_idx += 1;
 			}
-			else if (args[current_arg_idx] == "--enable-animation")
+			else if (args[current_arg_idx] == "--disable-animation")
 			{
-				commandLineOptions.enableAnimation = true;
+				commandLineOptions.disableAnimation = true;
 				current_arg_idx += 1;
+			}
+			else if (args[current_arg_idx] == "--rendering-mode")
+			{
+				if (current_arg_idx == num_args - 1)
+				{
+					printf("Command line parser: please provide a rendering mode [0 = Material, 1 = GBuffer, 2 = Debug].");
+					continue;
+				}
+				commandLineOptions.renderingMode = (RenderingMode)clamp(atoi(args[current_arg_idx + 1].c_str()), 0, 2);
+				current_arg_idx += 2;
+			}
+			else if (args[current_arg_idx] == "--texture-mode")
+			{
+				if (current_arg_idx == num_args - 1)
+				{
+					printf("Command line parser: please provide a texture mode ID [0 = Uncompressed, 1 = BC6, 2 = Neural].");
+					continue;
+				}
+				commandLineOptions.textureMode = (TextureMode)clamp(atoi(args[current_arg_idx + 1].c_str()), 0, 2);
+				current_arg_idx += 2;
+			}
+			else if (args[current_arg_idx] == "--filtering-mode")
+			{
+				if (current_arg_idx == num_args - 1)
+				{
+					printf("Command line parser: please provide a filtering mode ID [0 = Nearest, 1 = Linear, 2 = Anisotropic].");
+					continue;
+				}
+				commandLineOptions.filteringMode = (FilteringMode)clamp(atoi(args[current_arg_idx + 1].c_str()), 0, 2);
+				current_arg_idx += 2;
 			}
 			else if (args[current_arg_idx] == "--help")
 			{
 				printf("Option list:\n");
 				printf("--data-dir Location of the resource folders.\n");
-				printf("--adapter-id Integer that allows to pick the desired GPU.\n");
+				printf("--adapter-id Integer that allows to pick the desired GPU [-1 = Largest VRAM, >= 0 System adapter ID].\n");
 				printf("--poi Integer that allows to pick the initial camera location.\n");
 				printf("--disable-coop Disable cooperative vector usage at launch.\n");
-				printf("--enable-animation Enable mesh animation at launch.\n");
+				printf("--disable-animation Disable mesh animation at launch.\n");
+				printf("--rendering-mode Pick the rendering mode [0 = Material, 1 = GBuffer, 2 = Debug].\n");
+				printf("--texture-mode Pick the texture mode [0 = Uncompressed, 1 = BC6, 2 = Neural].\n");
+				printf("--filtering-mode Pick the filtering mode [0 = Nearest, 1 = Linear, 2 = Anisotropic].\n");
 				return false;
 			}
 			else


### PR DESCRIPTION
Answering the issue: https://github.com/GameTechDev/TextureSetNeuralCompressionSample/issues/3

- Adding clamp operator for int and float
- Adding the possibility to control rendering mode, texture mode and filtering mode from command line
- Fix the behavior of disable animation for the command line
- Print the picked GPU
- Change the adapter id behavior
- Update the readme to match the new command line options